### PR TITLE
Fix for issue #669

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,10 +341,16 @@ func serve(args []string) error {
 
 	if viper.GetBool("peer.validator.enabled") {
 		logger.Debug("Running as validating peer - installing consensus %s", viper.GetString("peer.validator.consensus"))
-		peerServer, _ = peer.NewPeerWithHandler(helper.NewConsensusHandler)
+		peerServer, err = peer.NewPeerWithHandler(helper.NewConsensusHandler)
 	} else {
 		logger.Debug("Running as non-validating peer")
-		peerServer, _ = peer.NewPeerWithHandler(peer.NewPeerHandler)
+		peerServer, err = peer.NewPeerWithHandler(peer.NewPeerHandler)
+	}
+
+	if err != nil {
+		logger.Fatalf("Failed creating new peer with handler %v", err)
+
+		return err
 	}
 
 	// Register the Peer server


### PR DESCRIPTION
come down gracefully when starting a peer with security enabled and the obcca server is not yet started.

Signed-by-off: Angelo De Caro <adc@zurich.ibm.com>